### PR TITLE
chore: Update merge commit template

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -40,3 +40,8 @@ Secret: $(hmac-token) in manifests
 SSL verification: Enable
 Which events would you like to trigger this webhook?: Send me everything.
 ```
+
+# Custom Tide Image
+
+The tide image used is a custom built one based on [this fork](https://github.com/ti-community-infra/test-infra) by the TiDB community.
+We use this for additional functionality for customizing commit messages as outlined [here](https://github.com/ti-community-infra/tichi/blob/master/docs/en/components/tide.md#custom-commit-message-template).

--- a/prow/kustomize/config.yaml
+++ b/prow/kustomize/config.yaml
@@ -61,6 +61,74 @@ data:
           title: "{{ .Title }} (#{{ .Number }})"
           body: |
             {{ .Body }}
+
+            {{- $signedAuthors := .NormalizeSignedOffBy -}}
+            {{- if $signedAuthors -}}{{- "\n\n" -}}{{- end -}}
+            {{- range $index, $author := $signedAuthors -}}
+              {{- if $index -}}{{- "\n" -}}{{- end -}}
+              {{- "Signed-off-by:" }} {{ .Name }} <{{- .Email -}}>
+            {{- end -}}
+
+            {{- $coAuthors := .NormalizeCoAuthorBy -}}
+            {{- if $coAuthors -}}{{- "\n\n" -}}{{- end -}}
+            {{- range $index, $author := $coAuthors -}}
+              {{- if $index -}}{{- "\n" -}}{{- end -}}
+              {{- "Co-authored-by:" }} {{ .Name }} <{{- .Email -}}>
+            {{- end -}}
+        kserve/modelmesh-serving:
+          title: "{{ .Title }} (#{{ .Number }})"
+          body: |
+            {{ .Body }}
+
+            {{- $signedAuthors := .NormalizeSignedOffBy -}}
+            {{- if $signedAuthors -}}{{- "\n\n" -}}{{- end -}}
+            {{- range $index, $author := $signedAuthors -}}
+              {{- if $index -}}{{- "\n" -}}{{- end -}}
+              {{- "Signed-off-by:" }} {{ .Name }} <{{- .Email -}}>
+            {{- end -}}
+
+            {{- $coAuthors := .NormalizeCoAuthorBy -}}
+            {{- if $coAuthors -}}{{- "\n\n" -}}{{- end -}}
+            {{- range $index, $author := $coAuthors -}}
+              {{- if $index -}}{{- "\n" -}}{{- end -}}
+              {{- "Co-authored-by:" }} {{ .Name }} <{{- .Email -}}>
+            {{- end -}}
+        kserve/modelmesh:
+          title: "{{ .Title }} (#{{ .Number }})"
+          body: |
+            {{ .Body }}
+
+            {{- $signedAuthors := .NormalizeSignedOffBy -}}
+            {{- if $signedAuthors -}}{{- "\n\n" -}}{{- end -}}
+            {{- range $index, $author := $signedAuthors -}}
+              {{- if $index -}}{{- "\n" -}}{{- end -}}
+              {{- "Signed-off-by:" }} {{ .Name }} <{{- .Email -}}>
+            {{- end -}}
+
+            {{- $coAuthors := .NormalizeCoAuthorBy -}}
+            {{- if $coAuthors -}}{{- "\n\n" -}}{{- end -}}
+            {{- range $index, $author := $coAuthors -}}
+              {{- if $index -}}{{- "\n" -}}{{- end -}}
+              {{- "Co-authored-by:" }} {{ .Name }} <{{- .Email -}}>
+            {{- end -}}
+        kserve/modelmesh-runtime-adapter:
+          title: "{{ .Title }} (#{{ .Number }})"
+          body: |
+            {{ .Body }}
+
+            {{- $signedAuthors := .NormalizeSignedOffBy -}}
+            {{- if $signedAuthors -}}{{- "\n\n" -}}{{- end -}}
+            {{- range $index, $author := $signedAuthors -}}
+              {{- if $index -}}{{- "\n" -}}{{- end -}}
+              {{- "Signed-off-by:" }} {{ .Name }} <{{- .Email -}}>
+            {{- end -}}
+
+            {{- $coAuthors := .NormalizeCoAuthorBy -}}
+            {{- if $coAuthors -}}{{- "\n\n" -}}{{- end -}}
+            {{- range $index, $author := $coAuthors -}}
+              {{- if $index -}}{{- "\n" -}}{{- end -}}
+              {{- "Co-authored-by:" }} {{ .Name }} <{{- .Email -}}>
+            {{- end -}}
       queries:
       - labels:
         - lgtm

--- a/prow/kustomize/kustomization.yaml
+++ b/prow/kustomize/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
 - config.yaml
 - plugins.yaml
 - prow-ibm-cloud.yaml
+images:
+  - name: gcr.io/k8s-prow/tide
+    newName: pvaneckw/tide
+    newTag: v20220329-v1.0.4
 configMapGenerator:
 - name: prow-parameters
   literals:


### PR DESCRIPTION
For modelmesh repos, tide will now customize the commit messages based on the PR descriptions. Signed-off-bys and Co-authored-bys will be de-duplicated. This should hopefully clean up the commit messages for large PRs with multiple commits.